### PR TITLE
Change type of width & height from int to string in order to handle dimensions in other units than 'px' (i.e. '%').

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ wp-content/plugins/hello.php
 /vendor
 
 .vscode
+.vs
 
 composer.lock
 package-lock.json

--- a/plugin/admin/options/class-options.php
+++ b/plugin/admin/options/class-options.php
@@ -107,7 +107,7 @@ class Options {
 		self::$root_path = new \Sgdd\Admin\Options\OptionTypes\PathField( 'root_path', '', 'basic', 'path_selection', [] );
 
 		self::$embed_width  = new \Sgdd\Admin\Options\OptionTypes\StringField( 'embed_width', __( 'Width', 'skaut-google-drive-documents' ), 'advanced', 'file', '100%' );
-		self::$embed_height = new \Sgdd\Admin\Options\OptionTypes\StringField( 'embed_height', __( 'Height', 'skaut-google-drive-documents' ), 'advanced', 'file', '600' );
+		self::$embed_height = new \Sgdd\Admin\Options\OptionTypes\StringField( 'embed_height', __( 'Height', 'skaut-google-drive-documents' ), 'advanced', 'file', '600px' );
 
 		self::$folder_type = new \Sgdd\Admin\Options\OptionTypes\SelectField( 'folder_type', __( 'Folder view type', 'skaut-google-drive-documents' ), 'advanced', 'folder', 'list' );
 

--- a/plugin/admin/options/class-options.php
+++ b/plugin/admin/options/class-options.php
@@ -106,12 +106,12 @@ class Options {
 
 		self::$root_path = new \Sgdd\Admin\Options\OptionTypes\PathField( 'root_path', '', 'basic', 'path_selection', [] );
 
-		self::$embed_width  = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'embed_width', __( 'Width', 'skaut-google-drive-documents' ), 'advanced', 'file', '800' );
-		self::$embed_height = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'embed_height', __( 'Height', 'skaut-google-drive-documents' ), 'advanced', 'file', '600' );
+		self::$embed_width  = new \Sgdd\Admin\Options\OptionTypes\StringField( 'embed_width', __( 'Width', 'skaut-google-drive-documents' ), 'advanced', 'file', '100%' );
+		self::$embed_height = new \Sgdd\Admin\Options\OptionTypes\StringField( 'embed_height', __( 'Height', 'skaut-google-drive-documents' ), 'advanced', 'file', '600' );
 
 		self::$folder_type = new \Sgdd\Admin\Options\OptionTypes\SelectField( 'folder_type', __( 'Folder view type', 'skaut-google-drive-documents' ), 'advanced', 'folder', 'list' );
 
-		self::$list_width = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'list_width', __( 'List width', 'skaut-google-drive-documents' ), 'advanced', 'folder', '800' );
+		self::$list_width = new \Sgdd\Admin\Options\OptionTypes\StringField( 'list_width', __( 'List width', 'skaut-google-drive-documents' ), 'advanced', 'folder', '100%' );
 		self::$grid_cols  = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'grid_cols', __( 'Grid columns', 'skaut-google-drive-documents' ), 'advanced', 'folder', '3' );
 	}
 }

--- a/plugin/public/block.php
+++ b/plugin/public/block.php
@@ -69,9 +69,9 @@ function add_block() {
 
 /**
  * Parses input string with dimension, e.g.:
- *  - 100 -> 100px,
- *  - 100px -> 100px,
- *  - 100% -> 100%.
+ *  - '100' -> '100px',
+ *  - '100px' -> '100px',
+ *  - '100%' -> '100%'.
  * 
  * @param $in Input string
  * @return string If $in contains only digits append to it 'px' otherwise return unmodified $in
@@ -175,7 +175,7 @@ function display( $attr ) {
 			$size .= 'height:' . parse_dimension( $attr['embedHeight'] ) . '; ';
 		}
 
-		$result = '<iframe src="https://drive.google.com/file/d/' . $id . '/preview" style="' . $size . 'border:0;"></iframe>';
+		$result = '<iframe class="sgdd-embedded-file" src="https://drive.google.com/file/d/' . $id . '/preview" style="' . $size . 'border:0;"></iframe>';
 
 		return $result;
 	}
@@ -325,6 +325,7 @@ function fetch_folder_content( $folder_id ) {
  */
 function build_result( $content, $type, $arg ) {
 	$result;
+	$style;
 
 	if ( empty( $content['files'] ) ) {
 		return 'Vybraný priečinok neobsahuje žiadne položky!';
@@ -333,10 +334,10 @@ function build_result( $content, $type, $arg ) {
 	if ( 'list' === $type ) {
 		//build list table
 		if ( ! empty( $arg ) ) {
-			$result = '<table style="width:' . parse_dimension( $arg['width'] ) . ';"><tbody>';
-		} else {
-			$result = '<table><tbody>';
+			$style = ' style="width:' . parse_dimension( $arg['width'] ) . ';"';
 		}
+
+		$result = '<table class="sgdd-embedded-folder-list"' . $style . '><tbody>';
 
 		foreach ( $content as $element ) {
 			$result .= '<tr>
@@ -352,11 +353,13 @@ function build_result( $content, $type, $arg ) {
 		$width;
 		$cols = $arg['cols'];
 
+		$style = ' style="table-layout:fixed; border-collapse:separate;';
 		if ( array_key_exists( 'width', $arg ) ) {
-			$result = '<table style="table-layout:fixed; border-collapse:separate; width:' . parse_dimension( $arg['width'] ) . ';"><tbody>';
-		} else {
-			$result = '<table style="table-layout:fixed; border-collapse:separate;"><tbody>';
+			$style .= ' width:' . parse_dimension( $arg['width'] ) . ';';
 		}
+		$style .= '"';
+
+		$result = '<table class="sgdd-embedded-folder-grid"' . $style . '><tbody>';
 
 		foreach ( $content as $element ) {
 			0 === ( $i % $cols ) ? $result .= '<tr>' : $result .= '';

--- a/plugin/public/block.php
+++ b/plugin/public/block.php
@@ -28,9 +28,10 @@ function register() {
 function add_block() {
 	\Sgdd\enqueue_script( 'sgdd_block_js', '/public/js/block.js', [ 'wp-blocks', 'wp-components', 'wp-editor', 'wp-element', 'wp-i18n', 'sgdd_file_selection_js' ] );
 	\Sgdd\enqueue_script( 'sgdd_file_selection_js', '/public/js/file-selection.js', [ 'wp-components', 'wp-element', 'sgdd_inspector_js', 'sgdd_settings_base_js' ] );
-	\Sgdd\enqueue_script( 'sgdd_inspector_js', '/public/js/inspector.js', [ 'wp-element', 'sgdd_integer_settings_js', 'sgdd_select_settings_js', 'sgdd_button_settings_js' ] );
+	\Sgdd\enqueue_script( 'sgdd_inspector_js', '/public/js/inspector.js', [ 'wp-element', 'sgdd_integer_settings_js', 'sgdd_string_settings_js', 'sgdd_select_settings_js', 'sgdd_button_settings_js' ] );
 	\Sgdd\enqueue_script( 'sgdd_settings_base_js', '/public/js/settings-base.js', [ 'wp-element' ] );
 	\Sgdd\enqueue_script( 'sgdd_integer_settings_js', '/public/js/integer-setting.js', [ 'wp-element', 'sgdd_settings_base_js' ] );
+	\Sgdd\enqueue_script( 'sgdd_string_settings_js', '/public/js/string-setting.js', [ 'wp-element', 'sgdd_settings_base_js' ] );
 	\Sgdd\enqueue_script( 'sgdd_select_settings_js', '/public/js/select-setting.js', [ 'wp-element', 'sgdd_settings_base_js' ] );
 	\Sgdd\enqueue_script( 'sgdd_button_settings_js', '/public/js/button-setting.js', [ 'wp-element' ] );
 
@@ -64,6 +65,25 @@ function add_block() {
 			'render_callback' => '\\Sgdd\\Pub\\Block\\display',
 		]
 	);
+}
+
+/**
+ * Parses input string with dimension, e.g.:
+ *  - 100 -> 100px,
+ *  - 100px -> 100px,
+ *  - 100% -> 100%.
+ * 
+ * @param $in Input string
+ * @return string If $in contains only digits append to it 'px' otherwise return unmodified $in
+ */
+function parse_dimension( $in ) {
+	$out = $in;
+
+	if ( ctype_digit( $in ) ) {
+		$out .= 'px';
+	}
+
+	return $out;
 }
 
 /**
@@ -148,11 +168,11 @@ function display( $attr ) {
 		$id   = $attr['fileId'];
 
 		if ( isset( $attr['embedWidth'] ) ) {
-			$size .= 'width:' . $attr['embedWidth'] . 'px; ';
+			$size .= 'width:' . parse_dimension( $attr['embedWidth'] ) . '; ';
 		}
 
 		if ( isset( $attr['embedHeight'] ) ) {
-			$size .= 'height:' . $attr['embedHeight'] . 'px; ';
+			$size .= 'height:' . parse_dimension( $attr['embedHeight'] ) . '; ';
 		}
 
 		$result = '<iframe src="https://drive.google.com/file/d/' . $id . '/preview" style="' . $size . 'border:0;"></iframe>';
@@ -313,7 +333,7 @@ function build_result( $content, $type, $arg ) {
 	if ( 'list' === $type ) {
 		//build list table
 		if ( ! empty( $arg ) ) {
-			$result = '<table style="width:' . $arg['width'] . 'px"><tbody>';
+			$result = '<table style="width:' . parse_dimension( $arg['width'] ) . ';"><tbody>';
 		} else {
 			$result = '<table><tbody>';
 		}
@@ -333,7 +353,7 @@ function build_result( $content, $type, $arg ) {
 		$cols = $arg['cols'];
 
 		if ( array_key_exists( 'width', $arg ) ) {
-			$result = '<table style="table-layout:fixed; border-collapse:separate; width:' . $arg['width'] . 'px"><tbody>';
+			$result = '<table style="table-layout:fixed; border-collapse:separate; width:' . parse_dimension( $arg['width'] ) . ';"><tbody>';
 		} else {
 			$result = '<table style="table-layout:fixed; border-collapse:separate;"><tbody>';
 		}

--- a/plugin/public/block.php
+++ b/plugin/public/block.php
@@ -325,7 +325,7 @@ function fetch_folder_content( $folder_id ) {
  */
 function build_result( $content, $type, $arg ) {
 	$result;
-	$style;
+	$style = '';
 
 	if ( empty( $content['files'] ) ) {
 		return 'Vybraný priečinok neobsahuje žiadne položky!';

--- a/plugin/public/css/block.css
+++ b/plugin/public/css/block.css
@@ -46,7 +46,7 @@
 	right: 0 !important;
 }
 
-.sgdd-block-settings-integer {
+.sgdd-block-settings-integer, .sgdd-block-settings-string {
 	margin: 0 !important;
 	width: 100px !important;
 	right: 0 !important;

--- a/plugin/public/js/block.js
+++ b/plugin/public/js/block.js
@@ -27,15 +27,15 @@ registerBlockType("skaut-google-drive-documents/block", {
       default: ""
     },
     embedWidth: {
-      type: "int",
+      type: "string",
       default: undefined
     },
     embedHeight: {
-      type: "int",
+      type: "string",
       default: undefined
     },
     listWidth: {
-      type: "int",
+      type: "string",
       default: undefined
     },
     gridCols: {

--- a/plugin/public/js/inspector.js
+++ b/plugin/public/js/inspector.js
@@ -16,12 +16,12 @@ SgddInspector.prototype.render = function() {
         key: "file-options"
       },
       [
-        el(SgddIntegerSetting, {
+        el(SgddStringSetting, {
           block: this.block,
           name: "embedWidth",
           key: "width"
         }),
-        el(SgddIntegerSetting, {
+        el(SgddStringSetting, {
           block: this.block,
           name: "embedHeight",
           key: "height"
@@ -36,7 +36,7 @@ SgddInspector.prototype.render = function() {
         key: "folder-options"
       },
       [
-        el(SgddIntegerSetting, {
+        el(SgddStringSetting, {
           block: this.block,
           name: "listWidth",
           key: "list-width"

--- a/plugin/public/js/string-setting.js
+++ b/plugin/public/js/string-setting.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const SgddStringSetting = function(attributes) {
+  SgddSettingsBase.call(this, attributes); //eslint-disable-line no-undef
+};
+
+SgddStringSetting.prototype = Object.create(SgddSettingsBase.prototype); //eslint-disable-line no-undef
+SgddStringSetting.prototype.renderInput = function() {
+  const that = this;
+  const value = this.block.getAttribute(this.name);
+  const el = wp.element.createElement;
+
+  return el("input", {
+    className: "sgdd-block-settings-string",
+    disabled: undefined === value,
+    key: this.name,
+    onChange(e) {
+      that.change(e);
+    },
+    placeholder: sgddBlockJsLocalize[this.name][1], //eslint-disable-line no-undef
+    type: "text",
+    value: this.state.value
+  });
+};
+SgddStringSetting.prototype.getValue = function(element) {
+  return element.value;
+};


### PR DESCRIPTION
- Handle dimensions (width & height) in other units than 'px' (ie. '%').
- For backward compatibility, values without units are treated as 'px'.
- The default width values are now set to "100%".
- Add CSS class name to embedded objects.