### PR TITLE
Implement of "Order by" for "Folder view type"

### DIFF
--- a/plugin/admin/options/class-options.php
+++ b/plugin/admin/options/class-options.php
@@ -73,11 +73,18 @@ class Options {
 	public static $embed_height;
 
 	/**
-	 * Wbether show folder as list or grif.
+	 * Whether show folder as list or grif.
 	 *
 	 * @var \Sgdd\Admin\Options\OptionTypes\SelectField $folder_type
 	 */
 	public static $folder_type;
+
+	/**
+	 * How to order files from folder.
+	 *
+	 * @var \Sgdd\Admin\Options\OptionTypes\SelectField $order_by
+	 */
+	public static $order_by;
 
 	/**
 	 * Width of list when displaying folder content as list.
@@ -110,6 +117,8 @@ class Options {
 		self::$embed_height = new \Sgdd\Admin\Options\OptionTypes\StringField( 'embed_height', __( 'Height', 'skaut-google-drive-documents' ), 'advanced', 'file', '600px' );
 
 		self::$folder_type = new \Sgdd\Admin\Options\OptionTypes\SelectField( 'folder_type', __( 'Folder view type', 'skaut-google-drive-documents' ), 'advanced', 'folder', 'list' );
+
+		self::$order_by = new \Sgdd\Admin\Options\OptionTypes\SelectField( 'order_by', __( 'Order files by', 'skaut-google-drive-documents' ), 'advanced', 'folder', 'name_asc' );
 
 		self::$list_width = new \Sgdd\Admin\Options\OptionTypes\StringField( 'list_width', __( 'List width', 'skaut-google-drive-documents' ), 'advanced', 'folder', '100%' );
 		self::$grid_cols  = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'grid_cols', __( 'Grid columns', 'skaut-google-drive-documents' ), 'advanced', 'folder', '3' );

--- a/plugin/admin/options/class-options.php
+++ b/plugin/admin/options/class-options.php
@@ -73,11 +73,18 @@ class Options {
 	public static $embed_height;
 
 	/**
-	 * Wbether show folder as list or grif.
+	 * Whether show folder as list or grif.
 	 *
 	 * @var \Sgdd\Admin\Options\OptionTypes\SelectField $folder_type
 	 */
 	public static $folder_type;
+
+	/**
+	 * How to order files from folder.
+	 *
+	 * @var \Sgdd\Admin\Options\OptionTypes\SelectField $order_by
+	 */
+	public static $order_by;
 
 	/**
 	 * Width of list when displaying folder content as list.
@@ -110,6 +117,8 @@ class Options {
 		self::$embed_height = new \Sgdd\Admin\Options\OptionTypes\StringField( 'embed_height', __( 'Height', 'skaut-google-drive-documents' ), 'advanced', 'file', '600' );
 
 		self::$folder_type = new \Sgdd\Admin\Options\OptionTypes\SelectField( 'folder_type', __( 'Folder view type', 'skaut-google-drive-documents' ), 'advanced', 'folder', 'list' );
+
+		self::$order_by = new \Sgdd\Admin\Options\OptionTypes\SelectField( 'order_by', __( 'Order files by', 'skaut-google-drive-documents' ), 'advanced', 'folder', 'name_asc' );
 
 		self::$list_width = new \Sgdd\Admin\Options\OptionTypes\StringField( 'list_width', __( 'List width', 'skaut-google-drive-documents' ), 'advanced', 'folder', '100%' );
 		self::$grid_cols  = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'grid_cols', __( 'Grid columns', 'skaut-google-drive-documents' ), 'advanced', 'folder', '3' );

--- a/plugin/admin/options/option-types/class-selectfield.php
+++ b/plugin/admin/options/option-types/class-selectfield.php
@@ -37,28 +37,43 @@ class SelectField extends SettingField {
 	 * @return int Sanitized value.
 	 */
 	public function sanitize( $value ) {
-		if ( 'pixels' === $value ) {
-			return 'pixels';
-		}
-
-		if ( 'percentage' === $value ) {
-			return 'percentage';
-		}
-
-		return $this->default_value;
+		return esc_html( $value );
 	}
 
 	/**
 	 * Display field for updating the option
 	 */
 	public function display() {
-		echo '<label for="sgdd-' . esc_attr( $this->id ) . '">
-						<input type="radio" id="sgdd-' . esc_attr( $this->id ) . '-list" name="' . esc_attr( $this->id ) . '" value="list" ' . ( $this->get() === 'list' ? 'checked' : '' ) . '> List
-					</label>
-					<br>
-					<label for="sgdd-' . esc_attr( $this->id ) . '">
-						<input type="radio" id="sgdd-' . esc_attr( $this->id ) . '-grid" name="' . esc_attr( $this->id ) . '" value="grid" ' . ( $this->get() === 'grid' ? 'checked' : '' ) . '> Grid
-					</label>
-		';
+		$display = '';
+		$inputs;
+
+		// Folder view type
+		if ( 'sgdd_folder_type' === $this->id ) {
+			$inputs = array(
+				array( 'list', __( 'List', 'skaut-google-drive-documents' ) ),
+				array( 'grid', __( 'Grid', 'skaut-google-drive-documents' ) )
+			);
+		}
+		// Order files by
+		else if ( 'sgdd_order_by' === $this->id ) {
+			$inputs = array(
+				array( 'name_asc', __( 'Name (ascending)', 'skaut-google-drive-documents' ) ),
+				array( 'name_dsc', __( 'Name (descending)', 'skaut-google-drive-documents' ) ),
+				array( 'time_asc', __( 'Time (ascending)', 'skaut-google-drive-documents' ) ),
+				array( 'time_dsc', __( 'Time (descending)', 'skaut-google-drive-documents' ) )
+			);
+		}
+
+		foreach ($inputs as &$input) {
+			if ( $display !== '' ) {
+				$display .= '<br>';
+			}
+
+			$display .= '<label for="sgdd-' . esc_attr( $this->id ) . '">
+					<input type="radio" id="sgdd-' . esc_attr( $this->id ) . "-" . $input[0] . '" name="' . esc_attr( $this->id ) . '" value="' . $input[0] . '" ' . ( $this->get() === $input[0] ? 'checked' : '' ) . '> ' . $input[1] .
+				'</label>';
+		}
+
+		echo $display;
 	}
 }

--- a/plugin/admin/settings-pages/advanced/embed.php
+++ b/plugin/admin/settings-pages/advanced/embed.php
@@ -28,6 +28,7 @@ function add() {
 	\Sgdd\Admin\Options\Options::$embed_width->add_field();
 	\Sgdd\Admin\Options\Options::$embed_height->add_field();
 	\Sgdd\Admin\Options\Options::$folder_type->add_field();
+	\Sgdd\Admin\Options\Options::$order_by->add_field();
 	\Sgdd\Admin\Options\Options::$list_width->add_field();
 	\Sgdd\Admin\Options\Options::$grid_cols->add_field();
 }

--- a/plugin/public/block.php
+++ b/plugin/public/block.php
@@ -121,9 +121,7 @@ function display( $attr ) {
 			$folder_type = \Sgdd\Admin\Options\Options::$folder_type->get();
 		}
 
-		if ( isset( $attr['orderBy'] ) ) {
-			$order_by = $attr['orderBy'];
-		}
+		$order_by = isset( $attr['orderBy'] ) ? $attr['orderBy'] : '';
 
 		//gdrive request to fetch content of folder
 		try {

--- a/plugin/public/block.php
+++ b/plugin/public/block.php
@@ -39,21 +39,26 @@ function add_block() {
 		'sgdd_block_js',
 		'sgddBlockJsLocalize',
 		[
-			'ajaxUrl'          => admin_url( 'admin-ajax.php' ),
-			'nonce'            => wp_create_nonce( 'sgdd_block_js' ),
-			'noncePerm'        => wp_create_nonce( 'sgdd_block_js_permissions' ),
-			'blockName'        => esc_html__( 'Google Drive Documents', 'skaut-google-drive-documents' ),
-			'blockDescription' => esc_html__( 'Embed your files from Google Drive', 'skaut-google-drive-documents' ),
-			'root'             => esc_html__( 'Google Drive', 'skaut-google-drive-documents' ),
-			'rootPath'         => \Sgdd\Admin\Options\Options::$root_path->get(),
-			'embedWidth'       => [ esc_html__( 'Width', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$embed_width->get() ],
-			'embedHeight'      => [ esc_html__( 'Height', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$embed_height->get() ],
-			'list'             => esc_html__( 'List', 'skaut-google-drive-documents' ),
-			'grid'             => esc_html__( 'Grid', 'skaut-google-drive-documents' ),
-			'folderType'       => [ esc_html__( 'List folder as', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$folder_type->get() ],
-			'listWidth'        => [ esc_html__( 'Width', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$list_width->get() ],
-			'gridCols'         => [ esc_html__( 'Grid columns', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$grid_cols->get() ],
-			'setPermissions'   => esc_html__( 'Set permissions' ),
+			'ajaxUrl'          	=> admin_url( 'admin-ajax.php' ),
+			'nonce'            	=> wp_create_nonce( 'sgdd_block_js' ),
+			'noncePerm'        	=> wp_create_nonce( 'sgdd_block_js_permissions' ),
+			'blockName'        	=> esc_html__( 'Google Drive Documents', 'skaut-google-drive-documents' ),
+			'blockDescription' 	=> esc_html__( 'Embed your files from Google Drive', 'skaut-google-drive-documents' ),
+			'root'             	=> esc_html__( 'Google Drive', 'skaut-google-drive-documents' ),
+			'rootPath'         	=> \Sgdd\Admin\Options\Options::$root_path->get(),
+			'embedWidth'       	=> [ esc_html__( 'Width', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$embed_width->get() ],
+			'embedHeight'      	=> [ esc_html__( 'Height', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$embed_height->get() ],
+			'list'             	=> esc_html__( 'List', 'skaut-google-drive-documents' ),
+			'grid'             	=> esc_html__( 'Grid', 'skaut-google-drive-documents' ),
+			'folderType'       	=> [ esc_html__( 'List folder as', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$folder_type->get() ],
+			'name_asc'         	=> esc_html__( 'Name (ascending)', 'skaut-google-drive-documents' ),
+			'name_dsc'         	=> esc_html__( 'Name (descending)', 'skaut-google-drive-documents' ),
+			'time_asc'         	=> esc_html__( 'Time (ascending)', 'skaut-google-drive-documents' ),
+			'time_dsc'         	=> esc_html__( 'Time (descending)', 'skaut-google-drive-documents' ),
+			'orderBy'			=> [ esc_html__( 'Order files by', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$order_by->get() ],
+			'listWidth'        	=> [ esc_html__( 'Width', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$list_width->get() ],
+			'gridCols'         	=> [ esc_html__( 'Grid columns', 'skaut-google-drive-documents' ), \Sgdd\Admin\Options\Options::$grid_cols->get() ],
+			'setPermissions'   	=> esc_html__( 'Set permissions', 'skaut-google-drive-documents' ),
 		]
 	);
 
@@ -93,12 +98,12 @@ function parse_dimension( $in ) {
  * @return string HTML format to display on frontend
  */
 function display( $attr ) {
+	// display folder
 	if ( isset( $attr['folderType'] ) || ! isset( $attr['fileId'] ) ) {
-		//display folder
 		$folder_id;
 		$folder_type;
+		$order_by;
 		$content;
-		$width;
 		$cols;
 		$result;
 
@@ -116,66 +121,51 @@ function display( $attr ) {
 			$folder_type = \Sgdd\Admin\Options\Options::$folder_type->get();
 		}
 
+		if ( isset( $attr['orderBy'] ) ) {
+			$order_by = $attr['orderBy'];
+		}
+
 		//gdrive request to fetch content of folder
 		try {
-			$content = fetch_folder_content( $folder_id );
+			$content = fetch_folder_content( $folder_id, $order_by );
 		} catch ( \Exception $e ) {
-			return '<div class="notice notice-error">Error while fetching folder content! <br> ' . $e . '</div>';
+			return '<div class="notice notice-error">' . __( 'Error while fetching folder content!', 'skaut-google-drive-documents' ) . '<br> ' . $e . '</div>';
 		}
 
-		if ( 'list' === $folder_type ) {
-			//display list
-			if ( isset( $attr['listWidth'] ) ) {
-				$result = build_result( $content, 'list', array( 'width' => $attr['listWidth'] ) );
-			} else {
-				$result = build_result( $content, 'list', array() );
-			}
+		$result_args = array();
+		if ( isset( $attr['listWidth'] ) ) {
+			$result_args['width'] = $attr['listWidth'];
+		}
+		if ( isset( $attr['gridCols'] ) ) {
+			$result_args['cols'] = $attr['gridCols'];	
 		} else {
-			//display grid
-			if ( isset( $attr['gridCols'] ) ) {
-				$cols = $attr['gridCols'];
-			} else {
-				$cols = \Sgdd\Admin\Options\Options::$grid_cols->get();
-			}
-
-			if ( isset( $attr['listWidth'] ) ) {
-				$result = build_result(
-					$content,
-					'grid',
-					array(
-						'width' => $attr['listWidth'],
-						'cols'  => $cols,
-					)
-				);
-			} else {
-				$result = build_result(
-					$content,
-					'grid',
-					array(
-						'cols' => $cols,
-					)
-				);
-			}
+			$result_args['cols'] = \Sgdd\Admin\Options\Options::$grid_cols->get();
 		}
 
-		$result .= '</tbody>
-								</table>';
+		$result = build_result(
+			$content,
+			'list' === $folder_type ? 'list' : 'grid',
+			$result_args
+		);
 
 		return $result;
-	} else {
-		//display file
-		$size = '';
+	}
+	// display file
+	else {
 		$id   = $attr['fileId'];
+		$style = 'style="border:0;';
 
 		if ( isset( $attr['embedWidth'] ) ) {
-			$size .= 'width:' . parse_dimension( $attr['embedWidth'] ) . '; ';
+			$style .= ' width:' . parse_dimension( $attr['embedWidth'] ) . '; ';
 		}
 
 		if ( isset( $attr['embedHeight'] ) ) {
-			$size .= 'height:' . parse_dimension( $attr['embedHeight'] ) . '; ';
+			$style .= ' height:' . parse_dimension( $attr['embedHeight'] ) . '; ';
 		}
 
-		$result = '<iframe class="sgdd-embedded-file" src="https://drive.google.com/file/d/' . $id . '/preview" style="' . $size . 'border:0;"></iframe>';
+		$style .= '"';
+
+		$result = '<iframe class="sgdd-embedded-file" src="https://drive.google.com/file/d/' . $id . '/preview" ' . $style . '></iframe>';
 
 		return $result;
 	}
@@ -288,9 +278,30 @@ function set_permissions_in_folder( $folder_id ) {
 	return $results;
 }
 
-function fetch_folder_content( $folder_id ) {
+function fetch_folder_content( $folder_id, $order_by ) {
 	$service    = \Sgdd\Admin\GoogleAPILib\get_drive_client();
 	$page_token = null;
+
+	switch ( $order_by ) {
+		case 'name_asc':
+			$order_by = "name";
+			break;
+
+		case 'name_dsc':
+			$order_by = "name desc";
+			break;
+
+		case 'time_asc':
+			$order_by = "modifiedTime";
+			break;
+
+		case 'time_dsc':
+			$order_by = "modifiedTime desc";
+			break;
+	
+		default:
+			$order_by = "";
+	}
 
 	do {
 		$response = $service->files->listFiles(
@@ -301,6 +312,7 @@ function fetch_folder_content( $folder_id ) {
 				'pageToken'                 => $page_token,
 				'pageSize'                  => 1000,
 				'fields'                    => 'files',
+				'orderBy'					=> 'folder' . ( !empty( $order_by ) ? ',' . $order_by : '' ),
 			)
 		);
 
@@ -328,12 +340,12 @@ function build_result( $content, $type, $arg ) {
 	$style;
 
 	if ( empty( $content['files'] ) ) {
-		return 'Vybraný priečinok neobsahuje žiadne položky!';
+		return '<div class="notice notice-info">' . __( 'The selected folder does not contain any items.', 'skaut-google-drive-documents' ) . '</div>';		
 	}
 
+	// build list table
 	if ( 'list' === $type ) {
-		//build list table
-		if ( ! empty( $arg ) ) {
+		if ( array_key_exists( 'width', $arg ) ) {
 			$style = ' style="width:' . parse_dimension( $arg['width'] ) . ';"';
 		}
 
@@ -341,16 +353,14 @@ function build_result( $content, $type, $arg ) {
 
 		foreach ( $content as $element ) {
 			$result .= '<tr>
-				<td><img src="' . $element['iconLink'] . '"></td>
-				<td><a href="' . $element['webViewLink'] . '" target="_blank">' . $element['name'] . '</a></td>
-			</tr>';
+					<td><img src="' . $element['iconLink'] . '"></td>
+					<td><a href="' . $element['webViewLink'] . '" target="_blank">' . $element['name'] . '</a></td>
+				</tr>';
 		}
-
-		return $result;
-	} else {
-		//build grid table
+	 }
+	// build grid table
+	else {
 		$i = 0;
-		$width;
 		$cols = $arg['cols'];
 
 		$style = ' style="table-layout:fixed; border-collapse:separate;';
@@ -362,17 +372,33 @@ function build_result( $content, $type, $arg ) {
 		$result = '<table class="sgdd-embedded-folder-grid"' . $style . '><tbody>';
 
 		foreach ( $content as $element ) {
-			0 === ( $i % $cols ) ? $result .= '<tr>' : $result .= '';
-
-			if ( ! $element['hasThumbnail'] || preg_match( '/\b(google-apps)/', $element['mimeType'] ) ) {
-				$result .= '<td><div class="element"><a href="' . $element['webViewLink'] . '" target="_blank"><div class="image"><img src="' . preg_replace( '(16)', '128', $element['iconLink'] ) . '"></div><div class="caption">' . $element['name'] . '</div></a></div></td>';
-			} else {
-				$result .= '<td><div class="element"><a href="' . $element['webViewLink'] . '" target="_blank"><div class="image"><img src="' . $element['thumbnailLink'] . '"></div><div class="caption">' . $element['name'] . '</div></a></div></td>';
+			if ( 0 === ( $i % $cols ) ) {
+				$result .= '<tr>';
 			}
-			$i % $cols === $cols - 1 ? $result .= '</tr>' : $result .= '';
+
+			$thumbnail = '';
+			if ( ! $element['hasThumbnail'] || preg_match( '/\b(google-apps)/', $element['mimeType'] ) ) {
+				$thumbnail = '<img src="' . preg_replace( '(16)', '128', $element['iconLink'] ) . '">';
+			} else {
+				$thumbnail = '<img src="' . $element['thumbnailLink'] . '">';
+			}
+
+			$result .= '<td><div class="sgdd-embedded-folder-element">
+					<a href="' . $element['webViewLink'] . '" target="_blank">
+						<div class="sgdd-embedded-folder-thumbnail">' . $thumbnail . '</div>
+						<div class="sgdd-embedded-folder-caption">' . $element['name'] . '</div>
+					</a>
+				</div></td>';
+			
+			if ( ( $i % $cols === $cols - 1 ) || ( ($i + 1) === sizeof( $content ) ) ) {
+				$result .= '</tr>';
+			}
+
 			$i++;
 		}
-
-		return $result;
 	}
+
+	$result .= '</tbody></table>';
+
+	return $result;
 }

--- a/plugin/public/css/block.css
+++ b/plugin/public/css/block.css
@@ -1,20 +1,22 @@
-.folder {
-  background-color: rgb(197, 218, 224);
-  font-weight: 500;
+.sgdd-block-settings-folder, .sgdd-block-settings-folder-up {
+	color: var(--wp-admin-theme-color);
+  	font-weight: bold;
 }
 
-.folder label {
-  color: #333333;
+.sgdd-block-settings-folder label::before {
+	content: "> ";
 }
 
-.file {
-  background-color: #ffffff;
-  color: #333333;
+.sgdd-block-settings-folder label, .sgdd-block-settings-folder-up label {
+	color: var(--wp-admin-theme-color);
 }
 
-.selected {
-  background-color: #c2ffa9;
-  font-weight: 600;
+.sgdd-block-settings-file-selected {
+	background-color: var(--wp-admin-theme-color) !important;
+}
+
+.sgdd-block-settings-file-selected label {
+	color: #fff;
 }
 
 .sgdd-block-icon {
@@ -65,27 +67,36 @@
 	display: inline-table;
 }
 
-.element {
+.sgdd-embedded-folder-grid td {
+	border-width: 0;
+	height: 0;
+}
+
+.sgdd-embedded-folder-grid tr, .sgdd-embedded-folder-list td {
+	vertical-align: top;
+}
+
+.sgdd-embedded-folder-element {
 	border: solid 1px;
 	border-color: rgba(51, 51, 51, 0.1);
 	border-radius: 10px;
 	margin: auto;
-	vertical-align: center;
+	vertical-align: middle;
 	padding: 10px;
+	height: 100%;
 }
 
-.image img {
+.sgdd-embedded-folder-element a, .sgdd-embedded-folder-list a {
+	text-decoration: none !important;
+}
+
+.sgdd-embedded-folder-thumbnail img {
 	display: block;
-	/*max-width: 100px;
-	max-height: 100px;*/
 	margin: auto;
 }
 
-.caption {
+.sgdd-embedded-folder-caption {
 	margin: auto;
 	text-align: center;
 }
 
-.caption a {
-	text-decoration: none !important;
-}

--- a/plugin/public/css/block.css
+++ b/plugin/public/css/block.css
@@ -3,10 +3,6 @@
   	font-weight: bold;
 }
 
-.sgdd-block-settings-folder label::before {
-	content: "> ";
-}
-
 .sgdd-block-settings-folder label, .sgdd-block-settings-folder-up label {
 	color: var(--wp-admin-theme-color);
 }

--- a/plugin/public/js/block.js
+++ b/plugin/public/js/block.js
@@ -45,6 +45,10 @@ registerBlockType("skaut-google-drive-documents/block", {
     folderType: {
       type: "string",
       default: undefined
+    },
+    orderBy: {
+      type: "string",
+      default: undefined
     }
   },
 

--- a/plugin/public/js/file-selection.js
+++ b/plugin/public/js/file-selection.js
@@ -40,9 +40,10 @@ SgddFileSelection.prototype.render = function() {
   const children = [];
   const namesPath = [
     el(
-      "a",
+      "label",
       {
-        key: "link",
+        className: "sgdd-block-settings-folder",
+        key: "path-root",
         onClick(e) {
           that.pathClick(that, e);
         }
@@ -67,10 +68,10 @@ SgddFileSelection.prototype.render = function() {
         children.unshift(
           el(
             "tr",
-            { className: "folder", key: "tr" + id },
+            { className: "sgdd-block-settings-folder", key: "tr-" + id },
             el(
               "td",
-              { key: "td" + id },
+              { key: "td-" + id },
               el(
                 "label",
                 {
@@ -83,34 +84,18 @@ SgddFileSelection.prototype.render = function() {
             )
           )
         );
-      } else if (id === this.getAttribute("fileId")) {
-        children.push(
-          el(
-            "tr",
-            { className: "selected", key: "tr" + id },
-            el(
-              "td",
-              { key: "td" + id },
-              el(
-                "label",
-                {
-                  onClick() {
-                    that.fileClick(that, id);
-                  }
-                },
-                this.state.list[i].fileName
-              )
-            )
-          )
-        );
       } else {
+        var style = "sgdd-block-settings-file";
+        if (id === this.getAttribute("fileId")) {
+          style += "-selected";
+        }
         children.push(
           el(
             "tr",
-            { className: "file", key: "tr" + id },
+            { className: style, key: "tr-" + id },
             el(
               "td",
-              { key: "td" + id },
+              { key: "td-" + id },
               el(
                 "label",
                 {
@@ -130,10 +115,11 @@ SgddFileSelection.prototype.render = function() {
       namesPath.push(" > ");
       namesPath.push(
         el(
-          "a",
+          "label",
           {
             "data-id": this.getAttribute("namesPath")[i],
-            key: i,
+            className: "sgdd-block-settings-folder",
+            key: "path-" + i,
             onClick(e) {
               that.pathClick(that, e);
             }
@@ -147,10 +133,10 @@ SgddFileSelection.prototype.render = function() {
       children.unshift(
         el(
           "tr",
-          { key: "tr_dots" },
+          { className: "sgdd-block-settings-folder-up", key: "tr-path-up" },
           el(
             "td",
-            { key: "td_dots" },
+            { key: "td-path-up" },
             el(
               "label",
               {
@@ -172,11 +158,11 @@ SgddFileSelection.prototype.render = function() {
       { key: "ic" },
       el(SgddInspector, { block: this }) //eslint-disable-line no-undef
     ),
-    el("table", { className: "widefat fixed", key: "table" }, [
+    el("table", { className: "widefat fixed striped", key: "table" }, [
       el(
         "thead",
         { key: "thead" },
-        el("tr", { key: "tr" }, el("th", { key: "th" }, namesPath))
+        el("tr", { key: "tr-thead" }, el("th", { key: "th-thead" }, namesPath))
       ),
 
       el("tbody", { key: "tbody" }, children),
@@ -184,7 +170,7 @@ SgddFileSelection.prototype.render = function() {
       el(
         "tfoot",
         { key: "tfoot" },
-        el("tr", { key: "tr" }, el("th", { key: "th" }, namesPath))
+        el("tr", { key: "tr-tfoot" }, el("th", { key: "th-tfoot" }, namesPath))
       )
     ])
   ]);

--- a/plugin/public/js/file-selection.js
+++ b/plugin/public/js/file-selection.js
@@ -1,263 +1,290 @@
-"use strict";
+'use strict';
 
-const SgddFileSelection = function(props) {
-  this.props = props;
-  this.state = { error: undefined, list: undefined };
+const SgddFileSelection = function ( props ) {
+	this.props = props;
+	this.state = { error: undefined, list: undefined };
 };
 
-SgddFileSelection.prototype = Object.create(wp.element.Component.prototype);
-SgddFileSelection.prototype.componentDidMount = function() {
-  this.ajax();
+SgddFileSelection.prototype = Object.create( wp.element.Component.prototype );
+SgddFileSelection.prototype.componentDidMount = function () {
+	this.ajax();
 };
 
-SgddFileSelection.prototype.ajax = function() {
-  const that = this;
-  jQuery.ajax({
-    url: sgddBlockJsLocalize.ajaxUrl, //eslint-disable-line no-undef
-    type: "GET",
-    data: {
-      action: "selectFile",
-      namesPath: this.getAttribute("namesPath"),
-      idsPath: this.getAttribute("idsPath"),
-      _ajax_nonce: sgddBlockJsLocalize.nonce // eslint-disable-line camelcase, no-undef
-    },
-    success(response) {
-      if (response.error) {
-        that.setState({ error: response.error });
-      } else {
-        that.setState({ list: response });
-      }
-    },
-    error(response) {
-      that.setState({ error: response.error });
-    }
-  });
+SgddFileSelection.prototype.ajax = function () {
+	const that = this;
+	jQuery.ajax( {
+		url: sgddBlockJsLocalize.ajaxUrl, //eslint-disable-line no-undef
+		type: 'GET',
+		data: {
+			action: 'selectFile',
+			namesPath: this.getAttribute( 'namesPath' ),
+			idsPath: this.getAttribute( 'idsPath' ),
+			_ajax_nonce: sgddBlockJsLocalize.nonce, // eslint-disable-line camelcase, no-undef
+		},
+		success( response ) {
+			if ( response.error ) {
+				that.setState( { error: response.error } );
+			} else {
+				that.setState( { list: response } );
+			}
+		},
+		error( response ) {
+			that.setState( { error: response.error } );
+		},
+	} );
 };
 
-SgddFileSelection.prototype.render = function() {
-  const el = wp.element.createElement;
-  const that = this;
-  const children = [];
-  const namesPath = [
-    el(
-      "label",
-      {
-        className: "sgdd-block-settings-folder",
-        key: "path-root",
-        onClick(e) {
-          that.pathClick(that, e);
-        }
-      },
-      sgddBlockJsLocalize.root //eslint-disable-line no-undef
-    )
-  ];
+SgddFileSelection.prototype.render = function () {
+	const el = wp.element.createElement;
+	const that = this;
+	const children = [];
+	const namesPath = [
+		el(
+			'label',
+			{
+				className: 'sgdd-block-settings-folder',
+				key: 'path-root',
+				onClick( e ) {
+					that.pathClick( that, e );
+				},
+			},
+			sgddBlockJsLocalize.root //eslint-disable-line no-undef
+		),
+	];
 
-  if (this.state.error) {
-    return el(
-      "div",
-      { className: "notice notice-error" },
-      el("p", {}, this.state.error)
-    );
-  }
+	if ( this.state.error ) {
+		return el(
+			'div',
+			{ className: 'notice notice-error' },
+			el( 'p', {}, this.state.error )
+		);
+	}
 
-  if (this.state.list) {
-    for (let i = 0; i < this.state.list.length; i++) {
-      const id = this.state.list[i].fileId;
+	if ( this.state.list ) {
+		for ( let i = 0; i < this.state.list.length; i++ ) {
+			const id = this.state.list[ i ].fileId;
 
-      if (this.state.list[i].folder) {
-        children.unshift(
-          el(
-            "tr",
-            { className: "sgdd-block-settings-folder", key: "tr-" + id },
-            el(
-              "td",
-              { key: "td-" + id },
-              el(
-                "label",
-                {
-                  onClick(e) {
-                    that.folderClick(that, e, id);
-                  }
-                },
-                this.state.list[i].fileName
-              )
-            )
-          )
-        );
-      } else {
-        var style = "sgdd-block-settings-file";
-        if (id === this.getAttribute("fileId")) {
-          style += "-selected";
-        }
-        children.push(
-          el(
-            "tr",
-            { className: style, key: "tr-" + id },
-            el(
-              "td",
-              { key: "td-" + id },
-              el(
-                "label",
-                {
-                  onClick() {
-                    that.fileClick(that, id);
-                  }
-                },
-                this.state.list[i].fileName
-              )
-            )
-          )
-        );
-      }
-    }
+			if ( this.state.list[ i ].folder ) {
+				children.unshift(
+					el(
+						'tr',
+						{
+							className: 'sgdd-block-settings-folder',
+							key: 'tr-' + id,
+						},
+						el(
+							'td',
+							{ key: 'td-' + id },
+							el(
+								'label',
+								{
+									className:
+										'dashicons-before dashicons-open-folder',
+									onClick( e ) {
+										that.folderClick( that, e, id );
+									},
+								},
+								this.state.list[ i ].fileName
+							)
+						)
+					)
+				);
+			} else {
+				let style = 'sgdd-block-settings-file';
+				if ( id === this.getAttribute( 'fileId' ) ) {
+					style += '-selected';
+				}
+				children.push(
+					el(
+						'tr',
+						{ className: style, key: 'tr-' + id },
+						el(
+							'td',
+							{ key: 'td-' + id },
+							el(
+								'label',
+								{
+									onClick() {
+										that.fileClick( that, id );
+									},
+								},
+								this.state.list[ i ].fileName
+							)
+						)
+					)
+				);
+			}
+		}
 
-    for (let i = 0, len = this.getAttribute("namesPath").length; i < len; i++) {
-      namesPath.push(" > ");
-      namesPath.push(
-        el(
-          "label",
-          {
-            "data-id": this.getAttribute("namesPath")[i],
-            className: "sgdd-block-settings-folder",
-            key: "path-" + i,
-            onClick(e) {
-              that.pathClick(that, e);
-            }
-          },
-          this.getAttribute("namesPath")[i]
-        )
-      );
-    }
+		for (
+			let i = 0, len = this.getAttribute( 'namesPath' ).length;
+			i < len;
+			i++
+		) {
+			namesPath.push(
+				el( 'span', {
+					className:
+						'sgdd-block-settings-folder dashicons dashicons-arrow-right-alt2',
+				} )
+			);
+			namesPath.push(
+				el(
+					'label',
+					{
+						'data-id': this.getAttribute( 'namesPath' )[ i ],
+						className: 'sgdd-block-settings-folder',
+						key: 'path-' + i,
+						onClick( e ) {
+							that.pathClick( that, e );
+						},
+					},
+					this.getAttribute( 'namesPath' )[ i ]
+				)
+			);
+		}
 
-    if (0 < this.getAttribute("namesPath").length) {
-      children.unshift(
-        el(
-          "tr",
-          { className: "sgdd-block-settings-folder-up", key: "tr-path-up" },
-          el(
-            "td",
-            { key: "td-path-up" },
-            el(
-              "label",
-              {
-                onClick() {
-                  that.upClick(that);
-                }
-              },
-              ".."
-            )
-          )
-        )
-      );
-    }
-  }
+		if ( 0 < this.getAttribute( 'namesPath' ).length ) {
+			children.unshift(
+				el(
+					'tr',
+					{
+						className: 'sgdd-block-settings-folder-up',
+						key: 'tr-path-up',
+					},
+					el(
+						'td',
+						{ key: 'td-path-up' },
+						el(
+							'label',
+							{
+								className:
+									'dashicons-before dashicons-arrow-left-alt2',
+								onClick() {
+									that.upClick( that );
+								},
+							},
+							'..'
+						)
+					)
+				)
+			);
+		}
+	}
 
-  return el(wp.element.Fragment, {}, [
-    el(
-      wp.blockEditor.InspectorControls,
-      { key: "ic" },
-      el(SgddInspector, { block: this }) //eslint-disable-line no-undef
-    ),
-    el("table", { className: "widefat fixed striped", key: "table" }, [
-      el(
-        "thead",
-        { key: "thead" },
-        el("tr", { key: "tr-thead" }, el("th", { key: "th-thead" }, namesPath))
-      ),
+	return el( wp.element.Fragment, {}, [
+		el(
+			wp.blockEditor.InspectorControls,
+			{ key: 'ic' },
+			el( SgddInspector, { block: this } ) //eslint-disable-line no-undef
+		),
+		el( 'table', { className: 'widefat fixed striped', key: 'table' }, [
+			el(
+				'thead',
+				{ key: 'thead' },
+				el(
+					'tr',
+					{ key: 'tr-thead' },
+					el( 'th', { key: 'th-thead' }, namesPath )
+				)
+			),
 
-      el("tbody", { key: "tbody" }, children),
+			el( 'tbody', { key: 'tbody' }, children ),
 
-      el(
-        "tfoot",
-        { key: "tfoot" },
-        el("tr", { key: "tr-tfoot" }, el("th", { key: "th-tfoot" }, namesPath))
-      )
-    ])
-  ]);
+			el(
+				'tfoot',
+				{ key: 'tfoot' },
+				el(
+					'tr',
+					{ key: 'tr-tfoot' },
+					el( 'th', { key: 'th-tfoot' }, namesPath )
+				)
+			),
+		] ),
+	] );
 };
 
-SgddFileSelection.prototype.getAttribute = function(name) {
-  return this.props.attributes[name];
+SgddFileSelection.prototype.getAttribute = function ( name ) {
+	return this.props.attributes[ name ];
 };
 
-SgddFileSelection.prototype.setAttribute = function(name, value) {
-  const attr = {};
-  attr[name] = value;
-  this.props.setAttributes(attr);
+SgddFileSelection.prototype.setAttribute = function ( name, value ) {
+	const attr = {};
+	attr[ name ] = value;
+	this.props.setAttributes( attr );
 };
 
-SgddFileSelection.prototype.upClick = function(that) {
-  let namesPath;
-  let idsPath;
-  let folderId;
+SgddFileSelection.prototype.upClick = function ( that ) {
+	let namesPath;
+	let idsPath;
+	let folderId;
 
-  if (that.getAttribute("namesPath").length === 1) {
-    namesPath = [];
-  } else {
-    namesPath = that
-      .getAttribute("namesPath")
-      .slice(0, that.getAttribute("namesPath").length - 1);
-  }
+	if ( that.getAttribute( 'namesPath' ).length === 1 ) {
+		namesPath = [];
+	} else {
+		namesPath = that
+			.getAttribute( 'namesPath' )
+			.slice( 0, that.getAttribute( 'namesPath' ).length - 1 );
+	}
 
-  if (that.getAttribute("idsPath").length === 1) {
-    idsPath = [];
-  } else {
-    idsPath = that
-      .getAttribute("idsPath")
-      .slice(0, that.getAttribute("idsPath").length - 1);
-  }
+	if ( that.getAttribute( 'idsPath' ).length === 1 ) {
+		idsPath = [];
+	} else {
+		idsPath = that
+			.getAttribute( 'idsPath' )
+			.slice( 0, that.getAttribute( 'idsPath' ).length - 1 );
+	}
 
-  if (idsPath.length < 1) {
-    folderId = "";
-  } else {
-    folderId = idsPath[idsPath.length - 1];
-  }
+	if ( idsPath.length < 1 ) {
+		folderId = '';
+	} else {
+		folderId = idsPath[ idsPath.length - 1 ];
+	}
 
-  that.setAttribute("namesPath", namesPath);
-  that.setAttribute("idsPath", idsPath);
-  that.setAttribute("folder", "true");
-  that.setAttribute("folderId", folderId);
-  that.setAttribute("fileId", "");
-  that.setState({ error: undefined, list: undefined }, that.ajax);
+	that.setAttribute( 'namesPath', namesPath );
+	that.setAttribute( 'idsPath', idsPath );
+	that.setAttribute( 'folder', 'true' );
+	that.setAttribute( 'folderId', folderId );
+	that.setAttribute( 'fileId', '' );
+	that.setState( { error: undefined, list: undefined }, that.ajax );
 };
 
-SgddFileSelection.prototype.pathClick = function(that, e) {
-  const $ = jQuery;
-  let namesPath = that.getAttribute("namesPath");
-  let idsPath = that.getAttribute("idsPath");
+SgddFileSelection.prototype.pathClick = function ( that, e ) {
+	const $ = jQuery;
+	let namesPath = that.getAttribute( 'namesPath' );
+	let idsPath = that.getAttribute( 'idsPath' );
 
-  namesPath = namesPath.slice(
-    0,
-    namesPath.indexOf($(e.currentTarget).data("id")) + 1
-  );
-  idsPath = idsPath.slice(
-    0,
-    namesPath.indexOf($(e.currentTarget).data("id")) + 1
-  );
+	namesPath = namesPath.slice(
+		0,
+		namesPath.indexOf( $( e.currentTarget ).data( 'id' ) ) + 1
+	);
+	idsPath = idsPath.slice(
+		0,
+		namesPath.indexOf( $( e.currentTarget ).data( 'id' ) ) + 1
+	);
 
-  that.setAttribute("namesPath", namesPath);
-  that.setAttribute("idsPath", idsPath);
-  that.setAttribute("folder", "true");
-  that.setAttribute("folderId", idsPath[idsPath.length - 1]);
-  that.setAttribute("fileId", "");
-  that.setState({ error: undefined, list: undefined }, that.ajax);
+	that.setAttribute( 'namesPath', namesPath );
+	that.setAttribute( 'idsPath', idsPath );
+	that.setAttribute( 'folder', 'true' );
+	that.setAttribute( 'folderId', idsPath[ idsPath.length - 1 ] );
+	that.setAttribute( 'fileId', '' );
+	that.setState( { error: undefined, list: undefined }, that.ajax );
 };
 
-SgddFileSelection.prototype.folderClick = function(that, e, id) {
-  const newFolder = jQuery(e.currentTarget).html();
-  const namesPath = that.getAttribute("namesPath").concat(newFolder);
-  const idsPath = that.getAttribute("idsPath").concat(id);
+SgddFileSelection.prototype.folderClick = function ( that, e, id ) {
+	const newFolder = jQuery( e.currentTarget ).html();
+	const namesPath = that.getAttribute( 'namesPath' ).concat( newFolder );
+	const idsPath = that.getAttribute( 'idsPath' ).concat( id );
 
-  that.setAttribute("namesPath", namesPath);
-  that.setAttribute("idsPath", idsPath);
-  that.setAttribute("folderId", id);
-  that.setAttribute("folder", "true");
-  that.setAttribute("fileId", "");
-  that.setState({ error: undefined, list: undefined }, that.ajax);
+	that.setAttribute( 'namesPath', namesPath );
+	that.setAttribute( 'idsPath', idsPath );
+	that.setAttribute( 'folderId', id );
+	that.setAttribute( 'folder', 'true' );
+	that.setAttribute( 'fileId', '' );
+	that.setState( { error: undefined, list: undefined }, that.ajax );
 };
 
-SgddFileSelection.prototype.fileClick = function(that, fileId) {
-  that.setAttribute("fileId", fileId);
-  that.setAttribute("folder", "false");
-  that.setState({ error: undefined, list: undefined }, that.ajax);
+SgddFileSelection.prototype.fileClick = function ( that, fileId ) {
+	that.setAttribute( 'fileId', fileId );
+	that.setAttribute( 'folder', 'false' );
+	that.setState( { error: undefined, list: undefined }, that.ajax );
 };

--- a/plugin/public/js/inspector.js
+++ b/plugin/public/js/inspector.js
@@ -51,6 +51,11 @@ SgddInspector.prototype.render = function() {
           name: "folderType",
           key: "folder-type"
         }),
+        el(SgddSelectSetting, {
+          block: this.block,
+          name: "orderBy",
+          key: "order-by"
+        }),
         el(SgddButtonSetting, {
           block: this.block,
           name: "setPermissions",

--- a/plugin/public/js/select-setting.js
+++ b/plugin/public/js/select-setting.js
@@ -9,57 +9,57 @@ SgddSelectSetting.prototype.renderInput = function() {
   const value = this.block.getAttribute(this.name);
   const el = wp.element.createElement;
 
-  return el(
-    "div",
-    { className: "sgdd-block-folder-type", key: "select-setting" },
-    [
-      el(
-        "label",
-        {
-          className: "sgdd-block-settings-radio",
-          key: this.name + "List",
-          htmlFor: this.name + "_list"
-        },
-        [
-          el("input", {
-            key: this.name + "ListInput",
-            checked: "list" === this.state.value,
-            disabled: undefined === value,
-            id: this.name + "_list",
-            name: this.name,
-            onChange(e) {
-              that.change(e);
-            },
-            type: "radio",
-            value: "list"
-          }),
-          sgddBlockJsLocalize.list //eslint-disable-line no-undef
-        ]
-      ),
-      el(
-        "label",
-        {
-          className: "sgdd-block-settings-radio",
-          key: this.name + "Grid",
-          htmlFor: this.name + "_grid"
-        },
-        [
-          el("input", {
-            key: this.name + "GridInput",
-            checked: "grid" === this.state.value,
-            disabled: undefined === value,
-            id: this.name + "_grid",
-            name: this.name,
-            onChange(e) {
-              that.change(e);
-            },
-            type: "radio",
-            value: "grid"
-          }),
-          sgddBlockJsLocalize.grid //eslint-disable-line no-undef
-        ]
-      )
-    ]
+  var inputs;
+  switch (this.name) {
+    case "orderBy":
+      var inputs = [ 
+        ["name_asc", sgddBlockJsLocalize.name_asc], //eslint-disable-line no-undef
+        ["name_dsc", sgddBlockJsLocalize.name_dsc], //eslint-disable-line no-undef
+        ["time_asc", sgddBlockJsLocalize.time_asc], //eslint-disable-line no-undef
+        ["time_dsc", sgddBlockJsLocalize.time_dsc]  //eslint-disable-line no-undef
+      ];
+      break;
+      
+    case "folderType":      
+      var inputs = [ 
+        ["list", sgddBlockJsLocalize.list], //eslint-disable-line no-undef
+        ["grid", sgddBlockJsLocalize.grid]  //eslint-disable-line no-undef
+      ];
+      break;
+  }
+
+  var elements = [];
+  for (const input of inputs) {
+    elements.push(el(
+      "label", {
+        className: "sgdd-block-settings-radio",
+        key: this.name + "-" + input[0] + "-Label",
+        htmlFor: this.name + "_" + input[0]
+      },
+      [
+        el("input", {
+          key: this.name + "-" + input[0] + "-Input",
+          checked: input[0] === this.state.value,
+          disabled: undefined === value,
+          id: this.name + "_" + input[0],
+          name: this.name,
+          onChange(e) {
+            that.change(e);
+          },
+          type: "radio",
+          value: input[0]
+        }),
+        input[1]
+      ]
+    ));
+  }
+
+  return  el(
+    "div", {
+      className: "sgdd-block-settings",
+      key: this.name + "Div"
+    },
+    elements
   );
 };
 


### PR DESCRIPTION
- Supporting order files by name (asc/desc) & time (asc/desc).
- Folders are always put on beginning of the list/grid.
- Fixed advanced options save settings for "Folder view type".
- Simplified code connected with generating table for "Folder view type".
- Added missed phrases in order to be translatable.
- Renamed CSS classes connected with "Folder view type" in order to be more unique.
- Improved CSS of "Google Drive Documents" block to be more compliant with WordPress admin theme.
- Minor fixes of default CSS for "Folder view type".