### PR TITLE
Implementation of option to hide "Google Drive Documents" from main menu

### DIFF
--- a/plugin/admin/admin-page.php
+++ b/plugin/admin/admin-page.php
@@ -46,6 +46,20 @@ function register_style() {
  * Adds menu to admin section.
  */
 function add_menu() {
+	// Hide "Google Drive Documents" menu from main admin menu
+	if ( get_option( \Sgdd\Admin\Options\Options::prefix . 'hide_gdd', 0 ) == 1 ) {
+		register_setting( 'general', \Sgdd\Admin\Options\Options::prefix . 'hide_gdd' );
+		add_settings_field(
+			\Sgdd\Admin\Options\Options::prefix . 'hide_gdd',
+			__( 'Google Drive Documents Menu', 'skaut-google-drive-documents' ),
+			function() {
+				\Sgdd\Admin\Options\Options::$hide_gdd->display();
+			},
+			'general'
+		);
+		return;
+	}
+
 	add_menu_page(
 		__( 'Google Drive Documents Settings', 'skaut-google-drive-documents' ),
 		__( 'Google Drive Documents', 'skaut-google-drive-documents' ),

--- a/plugin/admin/options/class-options.php
+++ b/plugin/admin/options/class-options.php
@@ -11,11 +11,17 @@ require_once __DIR__ . '/option-types/class-stringfield.php';
 require_once __DIR__ . '/option-types/class-pathfield.php';
 require_once __DIR__ . '/option-types/class-integerfield.php';
 require_once __DIR__ . '/option-types/class-selectfield.php';
+require_once __DIR__ . '/option-types/class-checkboxfield.php';
 
 /**
  * A class that contain all configuration settings of plugin.
  */
 class Options {
+	/**
+	 * Prefix added to option id during initialization.
+	 */
+	public const prefix = 'sgdd_';
+
 	/**
 	 * Show authorized domain for registering Google app.
 	 *
@@ -101,6 +107,13 @@ class Options {
 	public static $grid_cols;
 
 	/**
+	 * Hide Google Drive Documents Menu.
+	 * 
+	 * @var \Sgdd\Admin\Options\OptionTypes\CheckboxField $hide_gdd
+	 */
+	public static $hide_gdd;
+
+	/**
 	 * Class initializer function
 	 */
 	public static function init() {
@@ -121,6 +134,10 @@ class Options {
 		self::$order_by = new \Sgdd\Admin\Options\OptionTypes\SelectField( 'order_by', __( 'Order files by', 'skaut-google-drive-documents' ), 'advanced', 'folder', 'name_asc' );
 
 		self::$list_width = new \Sgdd\Admin\Options\OptionTypes\StringField( 'list_width', __( 'List width', 'skaut-google-drive-documents' ), 'advanced', 'folder', '100%' );
-		self::$grid_cols  = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'grid_cols', __( 'Grid columns', 'skaut-google-drive-documents' ), 'advanced', 'folder', '3' );
+		self::$grid_cols = new \Sgdd\Admin\Options\OptionTypes\IntegerField( 'grid_cols', __( 'Grid columns', 'skaut-google-drive-documents' ), 'advanced', 'folder', '3' );
+
+		self::$hide_gdd = new \Sgdd\Admin\Options\OptionTypes\CheckboxField( 'hide_gdd', __( 'Google Drive Documents Menu', 'skaut-google-drive-documents' ), 'advanced', 'other', 0,
+			__( 'Hide (Not recommended)' ),
+			__( 'This will hide the Google Drive Documents Menu (on the left side) and everything it contains. You can re-enable it through an option that will be added in Settings → General.' ) );
 	}
 }

--- a/plugin/admin/options/option-types/class-checkboxfield.php
+++ b/plugin/admin/options/option-types/class-checkboxfield.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * IntegerField class
+ *
+ * @package SGDD
+ * @since 1.0.0
+ */
+namespace Sgdd\Admin\Options\OptionTypes;
+
+require_once __DIR__ . '/class-settingfield.php';
+
+/**
+ * An option containing an checkbox value.
+ *
+ * @see CheckboxField
+ */
+class CheckboxField extends SettingField {
+	/**
+	 * Register option into WordPress.
+	 */
+	public function register() {
+		register_setting(
+			$this->page,
+			$this->id,
+			[
+				'type'              => 'integer',
+				'sanitize_callback' => [ $this, 'sanitize' ],
+				'default'           => $this->default_value,
+			]
+		);
+	}
+
+	/**
+	 * Sanitize the input.
+	 *
+	 * @param $value The unsanitized input.
+	 * @return boolean Sanitized value.
+	 */
+	public function sanitize( $value ) {
+		return ( 1 === absint( $value ) ) ? 1 : 0;
+	}
+
+	/**
+	 * Display field for updating the option
+	 */
+	public function display() {
+		echo "<label for='" . esc_attr( $this->id ) . "'>" . 
+				"<input type='checkbox' name='" . esc_attr( $this->id ) . "' id='" . esc_attr( $this->id ) . "' value='1' " . checked( 1, get_option( $this->id, $this->default_value ), false ) . ">" .
+				esc_attr( $this->label ) . "</label>" . 
+			"<p class='description'>" . esc_attr( $this->description ) . "</p>";
+	}
+}

--- a/plugin/admin/options/option-types/class-settingfield.php
+++ b/plugin/admin/options/option-types/class-settingfield.php
@@ -49,18 +49,22 @@ abstract class SettingField {
 	/**
 	 * SettingField class constructor.
 	 *
-	 * @param $id An unique name of the option used as key to reference it. Prefix "sgdd_" will be added.
-	 * @param @title Name of the option displayed to user.
-	 * @param $page Setting page in which the option will be displayed. Prefix "sgdd_" will be added.
-	 * @param $section Section within page in which the option will be displayed. Prefix "sgdd_" will be added.
-	 * @param $default_value Default valur of option if user do not specify one.
+	 * @param $id An unique name of the option used as key to reference it. Prefix Options::prefix will be added.
+	 * @param $title Name of the option displayed to user.
+	 * @param $page Setting page in which the option will be displayed. Prefix Options::prefix will be added.
+	 * @param $section Section within page in which the option will be displayed. Prefix Options::prefix will be added.
+	 * @param $default_value Default value of option if user do not specify one.
+	 * @param $label Label for checkbox.
+	 * @param $description Optional description.
 	 */
-	public function __construct( $id, $title, $page, $section, $default_value ) {
-		$this->id            = 'sgdd_' . $id;
+	public function __construct( $id, $title, $page, $section, $default_value, $label = '', $desciption = '' ) {
+		$this->id            = \Sgdd\Admin\Options\Options::prefix . $id;
 		$this->title         = $title;
-		$this->page          = 'sgdd_' . $page;
-		$this->section       = 'sgdd_' . $section;
+		$this->page          = \Sgdd\Admin\Options\Options::prefix . $page;
+		$this->section       = \Sgdd\Admin\Options\Options::prefix . $section;
 		$this->default_value = $default_value;
+		$this->label		 = $label;
+		$this->description	 = $desciption;
 	}
 
 	/**

--- a/plugin/admin/settings-pages/advanced.php
+++ b/plugin/admin/settings-pages/advanced.php
@@ -26,7 +26,14 @@ function register() {
  * Adds advanced settings page to admin menu.
  */
 function add_menu() {
-	add_submenu_page( 'sgdd_basic', __( 'Advanced options', 'skaut-google-drive-documents' ), esc_html__( 'Advanced options', 'skaut-google-drive-documents' ), 'manage_options', 'sgdd_advanced', '\\Sgdd\\Admin\\SettingsPages\\Advanced\\display' );
+	add_submenu_page(
+		'sgdd_basic',
+		__( 'Advanced options', 'skaut-google-drive-documents' ),
+		esc_html__( 'Advanced options', 'skaut-google-drive-documents' ),
+		'manage_options',
+		'sgdd_advanced',
+		'\\Sgdd\\Admin\\SettingsPages\\Advanced\\display'
+	);
 }
 
 /**
@@ -39,6 +46,7 @@ function display() {
 	?>
 	<div class="wrap">
 		<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+		<?php settings_errors(); ?>
 		<form action="options.php?action=update&option_page=sgdd_advanced" method="post">
 			<?php settings_fields( 'sgdd_advanced' ); ?>
 			<?php do_settings_sections( 'sgdd_advanced' ); ?>

--- a/plugin/admin/settings-pages/advanced/embed.php
+++ b/plugin/admin/settings-pages/advanced/embed.php
@@ -13,26 +13,47 @@ if ( ! is_admin() ) {
 }
 
 /**
- * Registers actions into WrodPress
+ * Registers actions into WordPress
  */
 function register() {
 	add_action( 'admin_init', '\\Sgdd\\Admin\\SettingsPages\\Advanced\\Embed\\add' );
 }
 
 /**
- * Adds settings field to advance settings page
+ * Adds settings field to advanced settings page
  */
 function add() {
-	add_settings_section( 'sgdd_file', esc_html__( 'File embed settings', 'skaut-google-drive-documents' ), '\\Sgdd\\Admin\\SettingsPages\\Advanced\\Embed\\display', 'sgdd_advanced' );
-	add_settings_section( 'sgdd_folder', esc_html__( 'Folder embed settings', 'skaut-google-drive-documents' ), '\\Sgdd\\Admin\\SettingsPages\\Advanced\\Embed\\display', 'sgdd_advanced' );
+	add_settings_section(
+		'sgdd_file',
+		esc_html__( 'File embed settings', 'skaut-google-drive-documents' ),
+		'\\Sgdd\\Admin\\SettingsPages\\Advanced\\Embed\\display',
+		'sgdd_advanced'
+	);
+
 	\Sgdd\Admin\Options\Options::$embed_width->add_field();
 	\Sgdd\Admin\Options\Options::$embed_height->add_field();
+
+	add_settings_section(
+		'sgdd_folder',
+		esc_html__( 'Folder embed settings', 'skaut-google-drive-documents' ),
+		'\\Sgdd\\Admin\\SettingsPages\\Advanced\\Embed\\display',
+		'sgdd_advanced'
+	);
+
 	\Sgdd\Admin\Options\Options::$folder_type->add_field();
 	\Sgdd\Admin\Options\Options::$order_by->add_field();
 	\Sgdd\Admin\Options\Options::$list_width->add_field();
 	\Sgdd\Admin\Options\Options::$grid_cols->add_field();
+
+	add_settings_section(
+		'sgdd_other',
+		esc_html__( 'Other settings', 'skaut-google-drive-documents' ),
+		'\\Sgdd\\Admin\\SettingsPages\\Advanced\\Embed\\display',
+		'sgdd_advanced'
+	);
+
+	\Sgdd\Admin\Options\Options::$hide_gdd->add_field();
 }
 
 function display() {
-	settings_errors();
 }

--- a/plugin/uninstall.php
+++ b/plugin/uninstall.php
@@ -12,10 +12,11 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die( 'None of your business' );
 }
 
-delete_option( 'sgdd_redirect_uri' );
-delete_option( 'sgdd_client_id' );
-delete_option( 'sgdd_client_secret' );
-
-delete_option( 'sgdd_access_token' );
-
-delete_option( 'sgdd_root_path' );
+$settingOptions = array( 'redirect_uri', 'client_id', 'client_secret',
+	'access_token', 'root_path', 'embed_width', 'embed_height', 'folder_type',
+	'order_by', 'list_width', 'grid_cols', 'hide_gdd');	
+ 
+// Clear up our settings
+foreach ( $settingOptions as $settingName ) {
+    delete_option( \Sgdd\Admin\Options\Options::prefix . $settingName );
+}


### PR DESCRIPTION
- hide "Google Drive Documents" menu from main admin menu & re-enable it through an option that will be added in Settings->General
- fixed saving advanced options to prevent duplicate showing error messages
- uninstall plugin causing now delete all options
